### PR TITLE
feat: adiciona transferencia entre contas bancarias

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -6,3 +6,4 @@ from models.transaction import Transaction
 from models.goal import Goal
 from models.invoice import Invoice
 from models.telegram_token import TelegramToken
+from models.transfer import Transfer

--- a/models/transfer.py
+++ b/models/transfer.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from extensions import db
+
+
+class Transfer(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    from_account_id = db.Column(db.Integer, db.ForeignKey('bank_account.id'), nullable=False)
+    to_account_id = db.Column(db.Integer, db.ForeignKey('bank_account.id'), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    description = db.Column(db.String(200))
+    date = db.Column(db.DateTime, default=datetime.utcnow)
+    is_confirmed = db.Column(db.Boolean, default=True)
+    status = db.Column(db.String(20), default='confirmado')
+    is_deleted = db.Column(db.Boolean, default=False)
+    deleted_at = db.Column(db.DateTime, nullable=True)
+
+    from_account = db.relationship(
+        'BankAccount',
+        foreign_keys=[from_account_id],
+        backref='outgoing_transfers',
+        lazy=True
+    )
+    to_account = db.relationship(
+        'BankAccount',
+        foreign_keys=[to_account_id],
+        backref='incoming_transfers',
+        lazy=True
+    )
+
+    def __repr__(self):
+        return f'<Transfer {self.from_account_id} -> {self.to_account_id} ({self.amount})>'

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, send_from_directory, send_file
 from flask_login import login_required, current_user
-from services import transaction_service, account_service, category_service, invoice_service
+from services import transaction_service, account_service, category_service, invoice_service, transfer_service
 from datetime import datetime
 import os
 from flask import current_app
@@ -156,6 +156,82 @@ def add():
         is_mei=current_user.is_mei,
         current_date=current_date
     )
+
+@transactions_bp.route('/transfer', methods=['GET', 'POST'])
+@login_required
+def transfer():
+    if current_user.is_admin:
+        flash('Administradores não possuem transferências.', 'info')
+        return redirect(url_for('admin.dashboard'))
+
+    accounts = account_service.get_user_accounts(current_user.id)
+
+    if request.method == 'POST':
+        from_account_id = request.form.get('from_account_id', type=int)
+        to_account_id = request.form.get('to_account_id', type=int)
+        amount = parse_brl_number(request.form.get('amount'))
+        description = request.form.get('description')
+        is_confirmed = 'is_confirmed' in request.form
+
+        transfer_date_str = request.form.get('transfer_date')
+        if transfer_date_str:
+            try:
+                transfer_date = datetime.strptime(transfer_date_str, '%Y-%m-%d')
+            except ValueError:
+                transfer_date = get_now_sp()
+        else:
+            transfer_date = get_now_sp()
+
+        transfer_record, message = transfer_service.create_transfer(
+            current_user.id,
+            from_account_id,
+            to_account_id,
+            amount,
+            description,
+            is_confirmed,
+            transfer_date
+        )
+
+        if not transfer_record:
+            flash(message, 'danger')
+            return redirect(url_for('transactions.transfer'))
+
+        flash(message, 'success')
+        return redirect(url_for('transactions.transfer'))
+
+    transfers = transfer_service.get_user_transfers(current_user.id, limit=20)
+    current_date = get_now_sp()
+
+    return render_template(
+        'transfer.html',
+        accounts=accounts,
+        transfers=transfers,
+        current_date=current_date
+    )
+
+@transactions_bp.route('/transfer/confirm/<int:transfer_id>')
+@login_required
+def confirm_transfer(transfer_id):
+    success, message = transfer_service.confirm_transfer(transfer_id, current_user.id)
+
+    if success:
+        flash(message, 'success')
+    else:
+        flash(message, 'warning')
+
+    return redirect(url_for('transactions.transfer'))
+
+@transactions_bp.route('/transfer/delete/<int:transfer_id>', methods=['POST'])
+@login_required
+def delete_transfer(transfer_id):
+    success, message = transfer_service.delete_transfer(transfer_id, current_user.id)
+
+    if success:
+        flash(message, 'success')
+    else:
+        flash(message, 'warning')
+
+    return redirect(url_for('transactions.transfer'))
 
 @transactions_bp.route('/edit/<int:transaction_id>', methods=['GET', 'POST'])
 @login_required

--- a/services/transfer_service.py
+++ b/services/transfer_service.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+
+from extensions import db
+from models import BankAccount, Transfer
+from utils.date_helpers import get_now_sp
+
+
+def get_user_transfers(user_id, limit=None):
+    query = Transfer.query.filter_by(user_id=user_id, is_deleted=False).order_by(Transfer.date.desc())
+    if limit:
+        return query.limit(limit).all()
+    return query.all()
+
+
+def get_transfer_by_id(transfer_id, user_id):
+    return Transfer.query.filter_by(id=transfer_id, user_id=user_id, is_deleted=False).first()
+
+
+def create_transfer(user_id, from_account_id, to_account_id, amount, description=None, is_confirmed=True, transfer_date=None):
+    from_account = BankAccount.query.filter_by(id=from_account_id, user_id=user_id, is_deleted=False).first()
+    if not from_account:
+        return None, "Conta de origem inválida"
+
+    to_account = BankAccount.query.filter_by(id=to_account_id, user_id=user_id, is_deleted=False).first()
+    if not to_account:
+        return None, "Conta de destino inválida"
+
+    if from_account.id == to_account.id:
+        return None, "A conta de origem deve ser diferente da conta de destino"
+
+    if amount is None or amount <= 0:
+        return None, "Informe um valor maior que zero"
+
+    if transfer_date is None:
+        transfer_date = get_now_sp()
+
+    status = 'confirmado' if is_confirmed else 'pendente'
+    transfer = Transfer(
+        user_id=user_id,
+        from_account_id=from_account.id,
+        to_account_id=to_account.id,
+        amount=amount,
+        description=description,
+        date=transfer_date,
+        is_confirmed=is_confirmed,
+        status=status
+    )
+
+    db.session.add(transfer)
+
+    if status == 'confirmado':
+        from_account.balance -= amount
+        to_account.balance += amount
+
+    db.session.commit()
+    return transfer, "Transferência registrada com sucesso"
+
+
+def confirm_transfer(transfer_id, user_id):
+    transfer = get_transfer_by_id(transfer_id, user_id)
+    if not transfer:
+        return False, "Transferência não encontrada"
+
+    if transfer.status != 'pendente':
+        return False, "Apenas transferências pendentes podem ser confirmadas"
+
+    transfer.status = 'confirmado'
+    transfer.is_confirmed = True
+    transfer.from_account.balance -= transfer.amount
+    transfer.to_account.balance += transfer.amount
+
+    db.session.commit()
+    return True, "Transferência confirmada com sucesso"
+
+
+def delete_transfer(transfer_id, user_id):
+    transfer = get_transfer_by_id(transfer_id, user_id)
+    if not transfer:
+        return False, "Transferência não encontrada"
+
+    if transfer.status == 'confirmado':
+        transfer.from_account.balance += transfer.amount
+        transfer.to_account.balance -= transfer.amount
+
+    transfer.is_deleted = True
+    transfer.deleted_at = datetime.utcnow()
+    db.session.commit()
+    return True, "Transferência excluída com sucesso"

--- a/templates/bank_accounts.html
+++ b/templates/bank_accounts.html
@@ -49,6 +49,9 @@
           <a href="{{ url_for('accounts.add') }}" class="btn btn-primary btn-sm">
             <i class="fas fa-plus"></i> Nova Conta
           </a>
+          <a href="{{ url_for('transactions.transfer') }}" class="btn btn-info btn-sm ml-2">
+            <i class="fas fa-exchange-alt"></i> Transferir
+          </a>
         </div>
       </div>
       <!-- /.card-header -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -410,6 +410,15 @@
                   <p>Adicionar Transação</p>
                 </a>
               </li>
+              <li class="nav-item">
+                <a
+                  href="{{ url_for('transactions.transfer') }}"
+                  class="nav-link {% if request.path == url_for('transactions.transfer') %}active{% endif %}"
+                >
+                  <i class="nav-icon fas fa-exchange-alt"></i>
+                  <p>Transferir entre Contas</p>
+                </a>
+              </li>
 
               <li class="nav-item">
                 <a

--- a/templates/mei_transactions.html
+++ b/templates/mei_transactions.html
@@ -12,6 +12,9 @@
           <a href="{{ url_for('transactions.add') }}" class="btn btn-primary btn-sm">
             <i class="fas fa-plus"></i> Nova Transação MEI
           </a>
+          <a href="{{ url_for('transactions.transfer') }}" class="btn btn-info btn-sm ml-2">
+            <i class="fas fa-exchange-alt"></i> Transferir
+          </a>
         </div>
       </div>
       <!-- /.card-header -->

--- a/templates/transactions.html
+++ b/templates/transactions.html
@@ -13,6 +13,9 @@
       <a href="{{ url_for('transactions.add') }}" class="btn btn-primary btn-sm">
         <i class="fas fa-plus"></i> {% if current_user.is_mei %}Nova Transação MEI{% else %}Nova Transação{% endif %}
       </a>
+      <a href="{{ url_for('transactions.transfer') }}" class="btn btn-info btn-sm ml-2">
+        <i class="fas fa-exchange-alt"></i> Transferir
+      </a>
       {% if is_mei %}
       <a href="{{ url_for('transactions.mei_transactions') }}" class="btn btn-success btn-sm ml-2">
         <i class="fas fa-building"></i> Transações MEI

--- a/templates/transfer.html
+++ b/templates/transfer.html
@@ -1,0 +1,191 @@
+{% extends 'base.html' %}
+
+{% block page_title %}Transferir entre Contas{% endblock %}
+{% block breadcrumb %}Transferir entre Contas{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-5">
+    <div class="card card-info">
+      <div class="card-header">
+        <h3 class="card-title">Nova Transferência</h3>
+      </div>
+      <form method="post" action="{{ url_for('transactions.transfer') }}">
+        <div class="card-body">
+          {% if accounts|length < 2 %}
+          <div class="alert alert-warning">
+            Cadastre pelo menos duas contas bancárias para fazer uma transferência.
+          </div>
+          {% endif %}
+
+          <div class="form-group">
+            <label for="from_account_id">Conta de origem</label>
+            <select class="form-control" id="from_account_id" name="from_account_id" required>
+              <option value="">Selecione a conta de origem</option>
+              {% for account in accounts %}
+              <option value="{{ account.id }}">{{ account.name }} ({{ account.balance|format_brl }})</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label for="to_account_id">Conta de destino</label>
+            <select class="form-control" id="to_account_id" name="to_account_id" required>
+              <option value="">Selecione a conta de destino</option>
+              {% for account in accounts %}
+              <option value="{{ account.id }}">{{ account.name }} ({{ account.balance|format_brl }})</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label for="amount">Valor</label>
+            <div class="input-group">
+              <div class="input-group-prepend">
+                <span class="input-group-text">R$</span>
+              </div>
+              <input type="text" class="form-control" id="amount" name="amount" placeholder="0,00" inputmode="decimal" required>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label for="description">Descrição</label>
+            <input type="text" class="form-control" id="description" name="description" placeholder="Ex: Reserva, investimento, conta digital">
+          </div>
+
+          <div class="form-group">
+            <label for="transfer_date">Data da Transferência</label>
+            <input type="date" class="form-control" id="transfer_date" name="transfer_date" value="{{ current_date.strftime('%Y-%m-%d') }}">
+          </div>
+
+          <div class="form-group">
+            <div class="custom-control custom-checkbox">
+              <input class="custom-control-input" type="checkbox" id="is_confirmed" name="is_confirmed" checked>
+              <label for="is_confirmed" class="custom-control-label">Transferência confirmada</label>
+            </div>
+            <small class="form-text text-muted">Transferências pendentes não alteram os saldos até serem confirmadas.</small>
+          </div>
+        </div>
+        <div class="card-footer">
+          <button type="submit" class="btn btn-info" {% if accounts|length < 2 %}disabled{% endif %}>
+            <i class="fas fa-exchange-alt"></i> Transferir
+          </button>
+          <a href="{{ url_for('transactions.index') }}" class="btn btn-default float-right">Voltar</a>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="col-md-7">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Últimas Transferências</h3>
+      </div>
+      <div class="card-body table-responsive p-0">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th>Data</th>
+              <th>Origem</th>
+              <th>Destino</th>
+              <th>Valor</th>
+              <th>Status</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for transfer in transfers %}
+            <tr>
+              <td>{{ transfer.date.strftime('%d/%m/%Y') }}</td>
+              <td>{{ transfer.from_account.name }}</td>
+              <td>{{ transfer.to_account.name }}</td>
+              <td>{{ transfer.amount|format_brl }}</td>
+              <td>
+                {% if transfer.status == 'confirmado' %}
+                <span class="badge bg-success">Confirmado</span>
+                {% else %}
+                <span class="badge bg-warning pending-badge">Pendente</span>
+                {% endif %}
+              </td>
+              <td>
+                <div class="btn-group">
+                  {% if transfer.status == 'pendente' %}
+                  <a href="{{ url_for('transactions.confirm_transfer', transfer_id=transfer.id) }}" class="btn btn-xs btn-success">
+                    <i class="fas fa-check"></i> Confirmar
+                  </a>
+                  {% endif %}
+                  <button type="button" class="btn btn-xs btn-danger" data-toggle="modal" data-target="#deleteTransferModal{{ transfer.id }}">
+                    <i class="fas fa-trash"></i> Excluir
+                  </button>
+                </div>
+
+                <div class="modal fade" id="deleteTransferModal{{ transfer.id }}" tabindex="-1" role="dialog" aria-hidden="true">
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h5 class="modal-title">Confirmar Exclusão</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                          <span aria-hidden="true">&times;</span>
+                        </button>
+                      </div>
+                      <div class="modal-body">
+                        <p>Tem certeza que deseja excluir esta transferência?</p>
+                        <p><strong>Origem:</strong> {{ transfer.from_account.name }}</p>
+                        <p><strong>Destino:</strong> {{ transfer.to_account.name }}</p>
+                        <p><strong>Valor:</strong> {{ transfer.amount|format_brl }}</p>
+                        {% if transfer.status == 'confirmado' %}
+                        <div class="alert alert-warning">
+                          <i class="fas fa-exclamation-triangle"></i> Excluir esta transferência irá devolver o valor para a origem e retirar o valor do destino.
+                        </div>
+                        {% endif %}
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+                        <form action="{{ url_for('transactions.delete_transfer', transfer_id=transfer.id) }}" method="post">
+                          <button type="submit" class="btn btn-danger">Excluir</button>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="6" class="text-center">Nenhuma transferência registrada</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const fromAccount = document.getElementById('from_account_id');
+  const toAccount = document.getElementById('to_account_id');
+
+  function updateAccountOptions() {
+    const fromValue = fromAccount.value;
+    const toValue = toAccount.value;
+
+    Array.from(toAccount.options).forEach(function(option) {
+      option.disabled = option.value && option.value === fromValue;
+    });
+
+    Array.from(fromAccount.options).forEach(function(option) {
+      option.disabled = option.value && option.value === toValue;
+    });
+  }
+
+  fromAccount.addEventListener('change', updateAccountOptions);
+  toAccount.addEventListener('change', updateAccountOptions);
+  updateAccountOptions();
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
Cria fluxo proprio para transferencias sem tratar o movimento como receita ou despesa. Adiciona modelo, servico, rota, tela de cadastro/historico e atalhos nas telas de contas e transacoes. Transferencias confirmadas ajustam os saldos das contas, pendentes aguardam confirmacao e exclusoes revertem o impacto quando necessario.
